### PR TITLE
Bump sweetalert2 dependency to latest (6.6.0)

### DIFF
--- a/package.json
+++ b/package.json
@@ -169,7 +169,7 @@
     "sass-loader": "^4.0.2",
     "spectron": "^3.5.0",
     "style-loader": "^0.13.1",
-    "sweetalert2": "^5.3.8",
+    "sweetalert2": "^6.6.0",
     "url-loader": "^0.5.7",
     "uuid": "^2.0.3",
     "webpack": "2.2.0",


### PR DESCRIPTION
First of all, thanks for the great open-sourced project you made! 

As the author of the `sweetalert2` dependency, I suggest to bump it to the latest.

There's the only one breaking change in the major release 6.0.0: https://github.com/limonte/sweetalert2/releases/tag/v6.0.0

Otherwise, a lot of improvements and bug-fixed were made since `^5.3.8`.

Greets from Turku :) Keep on good work!