### PR TITLE
Fix WebDAV connection issue, better error handling

### DIFF
--- a/package.json
+++ b/package.json
@@ -117,7 +117,7 @@
     "babel-register": "^6.18.0",
     "babili-webpack-plugin": "^0.0.8",
     "buttercup-importer": "~0.7.1",
-    "buttercup-ui": "^0.5.0",
+    "buttercup-ui": "^0.5.1",
     "buttercup-web": "~0.23.0",
     "classnames": "^2.2.5",
     "concurrently": "^2.1.0",

--- a/src/renderer/components/file-manager/sources/dropbox.js
+++ b/src/renderer/components/file-manager/sources/dropbox.js
@@ -6,6 +6,7 @@ import { Button, SmallType, Center } from 'buttercup-ui';
 import { Flex } from 'styled-flexbox';
 import { authenticateDropbox, getFsInstance } from '../../../system/auth';
 import { isButtercupFile } from '../../../system/utils';
+import { showDialog } from '../../../system/dialog';
 import Manager from '../manager';
 
 const DropboxButton = styled(Button)`
@@ -53,6 +54,7 @@ class Dropbox extends Component {
       })
       .catch(err => {
         console.error(err);
+        showDialog(`Connection to Dropbox server failed. Please try again later.`);
       });
   }
 

--- a/src/renderer/components/file-manager/sources/webdav.js
+++ b/src/renderer/components/file-manager/sources/webdav.js
@@ -72,7 +72,7 @@ class Webdav extends Component {
       });
     }).catch(err => {
       console.error(err);
-      showDialog(`Connection to ${this.state.endpoint} failed. Please check your credentials and try again.`);
+      showDialog(`Connection to ${endpoint} failed. Please check your credentials and try again.`);
     });
   }
 

--- a/src/renderer/components/file-manager/sources/webdav.js
+++ b/src/renderer/components/file-manager/sources/webdav.js
@@ -5,6 +5,7 @@ import { Flex } from 'styled-flexbox';
 import styled from 'styled-components';
 import { getFsInstance } from '../../../system/auth';
 import { isButtercupFile } from '../../../system/utils';
+import { showDialog } from '../../../system/dialog';
 import Manager from '../manager';
 
 const Form = styled.form`
@@ -53,7 +54,17 @@ class Webdav extends Component {
   }
 
   handleConnect = () => {
-    const fs = getFsInstance(this.props.owncloud ? 'owncloud' : 'webdav', this.state);
+    const { endpoint, username, password } = this.state;
+
+    if (!endpoint || !username || !password) {
+      return;
+    }
+
+    const fs = getFsInstance(
+      this.props.owncloud ? 'owncloud' : 'webdav',
+      { endpoint, username, password }
+    );
+
     fs.readDirectory('/').then(() => {
       this.fs = fs;
       this.setState({
@@ -61,6 +72,7 @@ class Webdav extends Component {
       });
     }).catch(err => {
       console.error(err);
+      showDialog(`Connection to ${this.state.endpoint} failed. Please check your credentials and try again.`);
     });
   }
 

--- a/src/renderer/system/dialog.js
+++ b/src/renderer/system/dialog.js
@@ -13,6 +13,13 @@ export function showConfirmDialog(message, fn) {
   });
 }
 
+export function showDialog(message, type = 'error') {
+  dialog.showMessageBox(currentWindow, {
+    type,
+    message
+  });
+}
+
 export function showPasswordDialog(preConfirm, options = {}) {
   return swal({
     title: 'Master Password',

--- a/yarn.lock
+++ b/yarn.lock
@@ -1776,9 +1776,9 @@ buttercup-importer@~0.7.1:
     kdbxweb "~1.0.1"
     xml2js "~0.4.13"
 
-buttercup-ui@^0.5.0:
-  version "0.5.0"
-  resolved "https://registry.yarnpkg.com/buttercup-ui/-/buttercup-ui-0.5.0.tgz#132f9fab70674b0749ea8d3e61c6e49f3f547daa"
+buttercup-ui@^0.5.1:
+  version "0.5.1"
+  resolved "https://registry.yarnpkg.com/buttercup-ui/-/buttercup-ui-0.5.1.tgz#bc99743583eae083fb288db7496a8a3af641b60e"
   dependencies:
     buttercup-generator "^0.0.2"
     classnames "^2.2.5"


### PR DESCRIPTION
Fixes #206 where a WebDAV connection issue was being caused by our custom `Button` element from `buttercup-ui` package not having a `type` property, so without a `type`, the `type` is always "submit", which was causing the webdav connection form to submit (navigate) before the code had a chance to connect to Yandex. Because Yandex's servers are slow, the "navigate" action (from the form submit) was happening earlier than react had a chance to re-render (as a result of successful connection). 

This PR also adds a few error dialogs and Fixes #207 