### PR TITLE
Global shortcut manager for archive window

### DIFF
--- a/package.json
+++ b/package.json
@@ -162,6 +162,7 @@
     "lodash": "^4.16.6",
     "makedeb": "0.0.4",
     "minimist": "^1.2.0",
+    "mousetrap": "^1.6.1",
     "ms": "^0.7.2",
     "node-noop": "^1.0.0",
     "node-sass": "^3.10.1",

--- a/src/main/config/menu/edit.js
+++ b/src/main/config/menu/edit.js
@@ -18,13 +18,9 @@ export default [
     role: 'cut'
   },
   {
-    label: 'Copy Password',
+    label: 'Copy',
     accelerator: 'CmdOrCtrl+C',
-    click(item, focusedWindow) {
-      if (focusedWindow) {
-        focusedWindow.rpc.emit('copy-current-password');
-      }
-    }
+    role: 'copy'
   },
   {
     label: 'Paste',

--- a/src/renderer/index.js
+++ b/src/renderer/index.js
@@ -6,20 +6,21 @@ import configureStore from '../shared/store/configure-store';
 import { loadArchiveFromSource } from '../shared/actions/archives';
 import * as groupActions from '../shared/actions/groups';
 import * as uiActions from '../shared/actions/ui';
-import { getCurrentEntry } from '../shared/selectors';
 import rpc from './system/rpc';
 import { getWorkspace } from './system/buttercup/archive';
 import { importHistoryFromRequest, showHistoryPasswordPrompt } from './system/buttercup/import';
-import { copyToClipboard, setWindowSize } from './system/utils';
+import { setWindowSize } from './system/utils';
+import { setupShortcuts } from './system/shortcuts';
 import Root from './containers/root';
 
 // Make crypto faster!
 Buttercup.Web.HashingTools.patchCorePBKDF();
 
 window.__defineGetter__('rpc', () => rpc);
-setWindowSize(870, 550);
-
 const store = configureStore({}, 'renderer');
+
+setWindowSize(870, 550);
+setupShortcuts(store);
 
 rpc.on('ready', () => {
   rpc.emit('init');
@@ -31,17 +32,6 @@ rpc.on('load-archive', payload => {
 
 rpc.on('is-in-workspace', () => {
   rpc.emit('in-workspace', getWorkspace() !== null);
-});
-
-rpc.on('copy-current-password', () => {
-  const selection = window.getSelection().toString();
-  const currentEntry = getCurrentEntry(store.getState());
-
-  if (selection !== '') {
-    copyToClipboard(selection);
-  } else if (currentEntry) {
-    copyToClipboard(currentEntry.properties.password);
-  }
 });
 
 rpc.on('size-change', size => {

--- a/src/renderer/system/shortcuts.js
+++ b/src/renderer/system/shortcuts.js
@@ -1,0 +1,17 @@
+import Mousetrap from 'mousetrap';
+import { getCurrentEntry } from '../../shared/selectors';
+import { copyToClipboard } from './utils';
+
+export const setupShortcuts = store => {
+  /**
+   * Copy password to clipboard
+   */
+  Mousetrap.bind('mod+c', () => {
+    const selection = window.getSelection().toString();
+    const currentEntry = getCurrentEntry(store.getState());
+
+    if (!selection && currentEntry) {
+      copyToClipboard(currentEntry.properties.password);
+    }
+  });
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -2203,7 +2203,7 @@ concat-map@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
 
-concat-stream@1.5.0, concat-stream@^1.4.7:
+concat-stream@1.5.0:
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/concat-stream/-/concat-stream-1.5.0.tgz#53f7d43c51c5e43f81c8fdd03321c631be68d611"
   dependencies:
@@ -2211,7 +2211,7 @@ concat-stream@1.5.0, concat-stream@^1.4.7:
     readable-stream "~2.0.0"
     typedarray "~0.0.5"
 
-concat-stream@^1.5.2:
+concat-stream@^1.4.7, concat-stream@^1.5.2:
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/concat-stream/-/concat-stream-1.6.0.tgz#0aac662fd52be78964d5532f694784e70110acf7"
   dependencies:
@@ -5526,6 +5526,10 @@ moment@^2.11.2:
   version "2.17.1"
   resolved "https://registry.yarnpkg.com/moment/-/moment-2.17.1.tgz#fed9506063f36b10f066c8b59a144d7faebe1d82"
 
+mousetrap@^1.6.1:
+  version "1.6.1"
+  resolved "https://registry.yarnpkg.com/mousetrap/-/mousetrap-1.6.1.tgz#2a085f5c751294c75e7e81f6ec2545b29cbf42d9"
+
 ms@0.7.1:
   version "0.7.1"
   resolved "https://registry.yarnpkg.com/ms/-/ms-0.7.1.tgz#9cd13c03adbff25b65effde7ce864ee952017098"
@@ -6891,7 +6895,7 @@ readable-stream@1.0.27-1:
     isarray "0.0.1"
     string_decoder "~0.10.x"
 
-readable-stream@^2, "readable-stream@^2.0.0 || ^1.1.13", readable-stream@^2.1.0, readable-stream@^2.1.4, readable-stream@^2.1.5, readable-stream@^2.2.2:
+readable-stream@^2, "readable-stream@^2.0.0 || ^1.1.13", readable-stream@^2.0.1, readable-stream@^2.0.2, readable-stream@^2.0.5, readable-stream@^2.1.0, readable-stream@^2.1.4, readable-stream@^2.1.5, readable-stream@^2.2.2:
   version "2.2.2"
   resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.2.2.tgz#a9e6fec3c7dda85f8bb1b3ba7028604556fc825e"
   dependencies:
@@ -6903,7 +6907,7 @@ readable-stream@^2, "readable-stream@^2.0.0 || ^1.1.13", readable-stream@^2.1.0,
     string_decoder "~0.10.x"
     util-deprecate "~1.0.1"
 
-readable-stream@^2.0.0, readable-stream@^2.0.1, readable-stream@^2.0.2, readable-stream@^2.0.5, readable-stream@~2.0.0, readable-stream@~2.0.5:
+readable-stream@^2.0.0, readable-stream@~2.0.0, readable-stream@~2.0.5:
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.0.6.tgz#8f90341e68a53ccc928788dacfcd11b36eb9b78e"
   dependencies:


### PR DESCRIPTION
Fixes #195 

As @lietu mentioned in #195, Chromium has a bug that prevents us from overriding global shortcuts like `Control+C` on Windows and Unix systems. To get around this, I have implemented an in-browser shortcut manager that fixes two issues:

+ Works on Windows and Linux
+ It doesn't override the native `Ctrl+C` behavior, so if anything else is selected in the window, it will be normally copied.