### PR TITLE
Add LastPass import option

### DIFF
--- a/package.json
+++ b/package.json
@@ -121,7 +121,7 @@
     "babel-preset-react-optimize": "^1.0.1",
     "babel-register": "^6.18.0",
     "babili-webpack-plugin": "^0.0.8",
-    "buttercup-importer": "^0.9.0",
+    "buttercup-importer": "~0.9.1",
     "buttercup-web": "~0.25.2",
     "classnames": "^2.2.5",
     "concurrently": "^2.1.0",

--- a/package.json
+++ b/package.json
@@ -121,7 +121,7 @@
     "babel-preset-react-optimize": "^1.0.1",
     "babel-register": "^6.18.0",
     "babili-webpack-plugin": "^0.0.8",
-    "buttercup-importer": "^0.8.0",
+    "buttercup-importer": "^0.9.0",
     "buttercup-web": "~0.25.2",
     "classnames": "^2.2.5",
     "concurrently": "^2.1.0",

--- a/src/main/config/menu/file.js
+++ b/src/main/config/menu/file.js
@@ -29,6 +29,10 @@ export default [
       {
         label: 'From 1Password archive (.1pif)',
         click: (item, focusedWindow) => openFileForImporting(focusedWindow, '1pif')
+      },
+      {
+        label: 'From LastPass archive (.csv)',
+        click: (item, focusedWindow) => openFileForImporting(focusedWindow, 'csv')
       }
     ]
   },

--- a/src/main/lib/buttercup.js
+++ b/src/main/lib/buttercup.js
@@ -1,4 +1,4 @@
-import { importFromKDBX, importFrom1PIF } from 'buttercup-importer';
+import { importFromKDBX, importFrom1PIF, importFromLastPass } from 'buttercup-importer';
 
 /**
  * Import archive from file
@@ -14,6 +14,8 @@ export function importArchive(type, filename, password) {
       return importFromKDBX(filename, password).then(archive => archive.getHistory());
     case '1pif':
       return importFrom1PIF(filename).then(archive => archive.getHistory());
+    case 'csv':
+      return importFromLastPass(filename).then(archive => archive.getHistory());
     default:
       throw new Error('Wrong import type provided');
   }

--- a/src/main/lib/files.js
+++ b/src/main/lib/files.js
@@ -117,6 +117,10 @@ const showImportDialog = function(focusedWindow, type) {
     'kdbx': {
       password: true,
       name: 'KeePass'
+    },
+    'csv': {
+      password: false,
+      name: 'LastPass'
     }
   };
   const typeInfo = types[type];


### PR DESCRIPTION
Just enables the LastPass options from here: https://github.com/buttercup/buttercup-importer/pull/12

Should probably wait until a new version of `buttercup-importer` is published with https://github.com/buttercup/buttercup-importer/pull/12 so I can bump the `buttercup-importer` version in `package.json` before merging this.