### PR TITLE
Remove update notice on restart

### DIFF
--- a/src/main/actions.js
+++ b/src/main/actions.js
@@ -1,12 +1,15 @@
 import { ipcMain as ipc, BrowserWindow } from 'electron';
 import fs from 'fs-extra';
-import { pushUpdate } from '../shared/actions/update';
+import { pushUpdate, updateInstalled } from '../shared/actions/update';
 import { getWindowManager } from './lib/window-manager';
 import { startAutoUpdate, installUpdates } from './lib/updater';
 
 const windowManager = getWindowManager();
 
 export function setupActions(store) {
+  // Clear update notice
+  store.dispatch(updateInstalled());
+
   if (process.env.NODE_ENV !== 'development') {
     try {
       startAutoUpdate((releaseNotes, releaseName) => {


### PR DESCRIPTION
This removes the update notice when the app starts, the reason is if the user hasn't clicked on the update notice to install the latest update and quits the app, the update automatically gets installed but the update notice is not immediately removed. 

Fixes #267 
